### PR TITLE
Responsive tweak 

### DIFF
--- a/sfm/ui/templates/base.html
+++ b/sfm/ui/templates/base.html
@@ -32,7 +32,7 @@
                     <div class="libheader-liblink">
                         <a href="http://library.gwu.edu" target="_blank" title="GW Libraries website">GW Libraries</a>
                     </div>
-                    <ul class="nav">
+                    <ul class="nav hide-med">
                         <li><a class="brand" href="{% url 'home' %}">social feed manager</a></li>
                         <li><a href="{% url 'about' %}">about</a></li>
                         <form method="get" action="{% url 'search' %}" class="navbar-search pull-left">


### PR DESCRIPTION
Added .hide-med class to <ul> at line 35, missed this in last commit (this will make it drop the search nav on lower res windows/screens as an interim fix to prevent it from wrapping into white space below the header)
