### PR TITLE
Reverse the admin URL for sub-path deployments

### DIFF
--- a/sfm/ui/templates/base.html
+++ b/sfm/ui/templates/base.html
@@ -40,7 +40,7 @@
                         </form>
                         {% if user.is_authenticated %}
                             {% if user.is_staff %}
-                            <li><a href="/admin/">admin</a></li>
+                            <li><a href="{% url 'admin:index' %}">admin</a></li>
                             <div class="bullet" style="">&bull;</div>
                             {% endif %}
                             <li><a href="{% url 'logout' %}">log out {{ user.username }}</a></li>


### PR DESCRIPTION
This is just a little patch that fixes the admin header link for sub-path deployments.
