### PR TITLE
strip leading @s from twitter usernames before saving

### DIFF
--- a/sfm/ui/models.py
+++ b/sfm/ui/models.py
@@ -116,6 +116,10 @@ class TwitterUser(m.Model):
     def counts(self):
         return ','.join([str(dc.num_tweets) for dc in self.daily_counts.all()])
 
+    def save(self, *args, **kwargs):
+        self.name = self.name.lstrip("@")
+        super(TwitterUser, self).save(*args, **kwargs)
+
 
 @receiver(post_save, sender=TwitterUser)
 def uid_update(sender, instance, **kwargs):


### PR DESCRIPTION
Override the TwitterUser model's save function to strip out leading '@'s. 

Caution: I don't know Python or Django very well!! This code is more or less cut and pasted from SO.

Copyright:
I hereby yield all rights to the content of this commit, anywhere in the universe, and for all eternity, to GWU Libraries.
