### PR TITLE
Added logic to throw clean ValidationErrors if name is not unique, but s...

### DIFF
--- a/sfm/ui/models.py
+++ b/sfm/ui/models.py
@@ -149,7 +149,7 @@ class TwitterUser(m.Model):
         dups = TwitterUser.objects.filter(uid=user_status['id'])
         if self.id is not None:
             # if updating (vs. creating), remove myself
-            dups.exclude(id=self.id)
+            dups = dups.exclude(id=self.id)
         if dups:
             raise ValidationError('TwitterUser uids must be unique. %s \
                                    is already present.' % user_status['id'])


### PR DESCRIPTION
...kip the rest as long as is_active==False - fixes #150. In the case where is_active==True, added smarter ValidationErrors to distinguish between bad API credential errors versus case where account name is not found in Twitter.   Also removed extraneous imports of post_save and receiver.
