### PR TITLE
T180 doc introduction

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -56,7 +56,7 @@ Contact us
 ^^^^^^^^^^
 
 - `sfm-dev Google Group <https://groups.google.com/forum/#!forum/sfm-dev>`_
-- Developers responsible for the app include Dan Chudnov (@dchud) and Dan Kerchner (@kerchner). 
+- Developers responsible for the app include Dan Chudnov (`@dchud <http://twitter.com/dchud/>`_) and Dan Kerchner (`@dankerchner <http://twitter.com/dankerchner/>`_). 
 
 Resources
 ^^^^^^^^^


### PR DESCRIPTION
What is the relationship between readthedocs and blog posts? Wondering if this should point to STG blog (or particular posts) for more background/news.
