### PR TITLE
Pinned requests version back to 2.5.3 to avoid causing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-social-auth
 lxml
 psycopg2
 pytz
-requests>2.4.1
+requests==2.5.3
 south
 tweepy==3.2.0
 supervisor


### PR DESCRIPTION
InsecurePlatformWarning.  Partly addresses #307

To test this, pip install your virtualenv on master.  Try running runserver, and you should see] the warning.  Blow away your virtualenv, and reinstall with this branch.  Run runserver and observe that the warning does not occur.